### PR TITLE
Bumped version to 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zigbee-adapter",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Zigbee adapter plugin for Mozilla IoT Gateway",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I realized that I should use 0.3.1 rather than 0.3.0
since this code wasn't included in the 0.3.0 release.