### PR TITLE
Add support for UARTSBee

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zigbee-adapter",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Zigbee adapter plugin for Mozilla IoT Gateway",
   "author": "Mozilla IoT",
   "main": "index.js",
@@ -56,17 +56,23 @@
     "plugin": true,
     "exec": "{nodeLoader} {path}",
     "config": {
-      "scanChannels": 8190
+      "scanChannels": 8190,
+      "allowFTDISerial": false
     },
     "schema": {
       "type": "object",
       "required": [
-        "scanChannels"
+        "scanChannels",
+        "allowFTDISerial"
       ],
       "properties": {
         "scanChannels": {
           "type": "integer",
           "default": 8190
+        },
+        "allowFTDISerial": {
+          "type": "boolean",
+          "default": false
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "zigbee-adapter",
+  "display_name": "Zigbee",
   "version": "0.3.5",
   "description": "Zigbee adapter plugin for Mozilla IoT Gateway",
   "author": "Mozilla IoT",


### PR DESCRIPTION
When unable to find a Zigbee dongle, report the serial
ports that were found (makes debugging easier).