### PR TITLE
Fix bug in classifying color lights

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zigbee-adapter",
   "display_name": "Zigbee",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Zigbee adapter plugin for Mozilla IoT Gateway",
   "author": "Mozilla IoT",
   "main": "index.js",

--- a/zb-classifier.js
+++ b/zb-classifier.js
@@ -553,7 +553,8 @@ class ZigbeeClassifier {
     }
     let colorSupported = false;
     if (lightLinkEndpoint) {
-      if ((node.colorCapabilities & 3) != 0) {
+      if (node.hasOwnProperty('colorCapabilities') &&
+          (node.colorCapabilities & 3) != 0) {
         // Hue and Saturation are supported
         colorSupported = true;
         node.type = Constants.THING_TYPE_ON_OFF_COLOR_LIGHT;

--- a/zb-node.js
+++ b/zb-node.js
@@ -66,7 +66,6 @@ class ZigbeeNode extends Device {
     }
     this.discoveringAttributes = false;
     this.fireAndForget = false;
-    this.colorCapabilities = 0;
     this.extendedTimeout = false;
     this.added = false;
   }


### PR DESCRIPTION
This was introduced in the last release when support
for sensors was added.