### PR TITLE
Update 16-bit address

### DIFF
--- a/zb-adapter.js
+++ b/zb-adapter.js
@@ -964,9 +964,20 @@ class ZigbeeAdapter extends Adapter {
       return this.findNodeByAddr16(addr16);
     }
 
+    let saveDeviceInfo = false;
     let node = this.nodes[addr64];
-    if (!node) {
+    if (node) {
+      // Update the 16-bit address, since it may have changed.
+      if (node.addr16 != addr16) {
+        node.addr16 = addr16;
+        saveDeviceInfo = true;
+      }
+    } else {
       node = this.nodes[addr64] = new ZigbeeNode(this, addr64, addr16);
+      saveDeviceInfo = true;
+    }
+    if (saveDeviceInfo) {
+      this.saveDeviceInfoDeferred();
     }
     return node;
   }


### PR DESCRIPTION
When devices (like lights) rejoin the network, perhaps because they've
been physically turned off, their 16-bit address may change. Update
it and re-save the device info of this happens. This was a regression
introduced when adding persistence.