### PR TITLE
Set the API Mode if it isn't set properly

### DIFF
--- a/zb-adapter.js
+++ b/zb-adapter.js
@@ -255,6 +255,8 @@ class ZigbeeAdapter extends Adapter {
       });
 
       this.queueCommands([
+        this.AT(AT_CMD.API_MODE),
+        FUNC(this, this.configureApiModeIfNeeded),
         this.AT(AT_CMD.DEVICE_TYPE_IDENTIFIER),
         this.AT(AT_CMD.CONFIGURED_64_BIT_PAN_ID),
         this.AT(AT_CMD.SERIAL_NUMBER_HIGH),
@@ -336,6 +338,26 @@ class ZigbeeAdapter extends Adapter {
         command: command,
       }),
     ];
+  }
+
+  configureApiModeIfNeeded() {
+    if (this.debugFlow) {
+      console.log('configureApiModeIfNeeded');
+    }
+    const configCommands = [];
+    if (this.apiMode != 1) {
+      configCommands.push(this.AT(AT_CMD.API_MODE,
+                                  {apiMode: 1}));
+      configCommands.push(this.AT(AT_CMD.API_MODE));
+    }
+
+    if (configCommands.length > 0) {
+      console.log('Setting API mode to 1');
+      configCommands.push(this.AT(AT_CMD.WRITE_PARAMETERS));
+      this.queueCommandsAtFront(configCommands);
+    } else {
+      console.log('API Mode already set to 1 (i.e. no need to change');
+    }
   }
 
   configureIfNeeded() {
@@ -2215,6 +2237,7 @@ class ZigbeeAdapter extends Adapter {
 
 const acm = ZigbeeAdapter.atCommandMap = {};
 acm[AT_CMD.API_OPTIONS] = 'apiOptions';
+acm[AT_CMD.API_MODE] = 'apiMode';
 acm[AT_CMD.CONFIGURED_64_BIT_PAN_ID] = 'configuredPanId64';
 acm[AT_CMD.DEVICE_TYPE_IDENTIFIER] = 'deviceTypeIdentifier';
 acm[AT_CMD.ENCRYPTION_ENABLED] = 'encryptionEnabled';

--- a/zb-adapter.js
+++ b/zb-adapter.js
@@ -356,7 +356,7 @@ class ZigbeeAdapter extends Adapter {
       configCommands.push(this.AT(AT_CMD.WRITE_PARAMETERS));
       this.queueCommandsAtFront(configCommands);
     } else {
-      console.log('API Mode already set to 1 (i.e. no need to change');
+      console.log('API Mode already set to 1 (i.e. no need to change)');
     }
   }
 

--- a/zb-at.js
+++ b/zb-at.js
@@ -28,6 +28,9 @@ ac[ac.APPLY_CHANGES] = 'Apply Changes (AC)';
 ac.API_OPTIONS = 'AO';
 ac[ac.API_OPTIONS] = 'API Options (AO)';
 
+ac.API_MODE = 'AP';
+ac[ac.API_MODE] = 'API Mode';
+
 ac.OPERATING_CHANNEL = 'CH';
 ac[ac.OPERATING_CHANNEL] = 'Operating Channel (CH)';
 
@@ -130,6 +133,10 @@ exports.AtApi = AtApi;
 //
 // ---------------------------------------------------------------------------
 
+atBuilder[ac.API_MODE] = function(frame, builder) {
+  builder.appendUInt8(frame.apiMode);
+};
+
 atBuilder[ac.API_OPTIONS] = function(frame, builder) {
   builder.appendUInt8(frame.apiOptions);
 };
@@ -187,6 +194,10 @@ atBuilder[ac.ZIGBEE_STACK_PROFILE] = function(frame, builder) {
 // Parsers
 //
 // ---------------------------------------------------------------------------
+
+atParser[ac.API_MODE] = function(frame, reader) {
+  frame.apiMode = reader.nextUInt8();
+};
 
 atParser[ac.API_OPTIONS] = function(frame, reader) {
   frame.apiOptions = reader.nextUInt8();


### PR DESCRIPTION
The Digi dongles are supposed to come from the factory
with AP mode set to 1, but some come with AP mode set
to 2. Mode 2 caused character escaping to occur which
messes things up when you're not expecting it.