### PR TITLE
Requery the cieAddr when classifying the device

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zigbee-adapter",
   "display_name": "Zigbee",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "Zigbee adapter plugin for Mozilla IoT Gateway",
   "author": "Mozilla IoT",
   "main": "index.js",

--- a/zb-adapter.js
+++ b/zb-adapter.js
@@ -72,13 +72,13 @@ const CLUSTER_ID_SSIASZONE = zclId.cluster('ssIasZone').value;
 const CLUSTER_ID_SSIASZONE_HEX = utils.hexStr(CLUSTER_ID_SSIASZONE, 4);
 
 const ATTR_ID_SSIASZONE_ZONESTATE =
-  zclId.attr(CLUSTER_ID_SSIASZONE, 'zoneState').value;
+  zclId.attr(CLUSTER_ID_SSIASZONE, 'zoneState').value;    // 0
 const ATTR_ID_SSIASZONE_ZONETYPE =
-  zclId.attr(CLUSTER_ID_SSIASZONE, 'zoneType').value;
+  zclId.attr(CLUSTER_ID_SSIASZONE, 'zoneType').value;     // 1
 const ATTR_ID_SSIASZONE_ZONESTATUS =
-  zclId.attr(CLUSTER_ID_SSIASZONE, 'zoneStatus').value;
+  zclId.attr(CLUSTER_ID_SSIASZONE, 'zoneStatus').value;   // 2
 const ATTR_ID_SSIASZONE_CIEADDR =
-  zclId.attr(CLUSTER_ID_SSIASZONE, 'iasCieAddr').value;
+  zclId.attr(CLUSTER_ID_SSIASZONE, 'iasCieAddr').value;   // 16
 
 const STATUS_SUCCESS = zclId.status('success').value;
 

--- a/zb-classifier.js
+++ b/zb-classifier.js
@@ -980,6 +980,9 @@ class ZigbeeClassifier {
       '',                             // setAttrFromValue
       ''                              // parseValueFromAttr
     ).mask = ZONE_STATUS_LOW_BATTERY_MASK;
+
+    // Remove the cieAddr so that we'll requery it from the device.
+    delete node.cieAddr;
   }
 
   addProperty(node, name, descr, profileId, endpoint, clusterId,


### PR DESCRIPTION
This fixes an issue where the smarthings sensors
appear to go non-responsive after removing and
re-adding them.