### PR TITLE
Fix typo in the name of lumi.sensor_magnet

### DIFF
--- a/zb-xiaomi.js
+++ b/zb-xiaomi.js
@@ -30,7 +30,7 @@ const {
 
 const MODEL_IDS = {
   'lumi.sensor_magnet': {
-    name: 'magent',
+    name: 'magnet',
     type: Constants.THING_TYPE_BINARY_SENSOR,
     '@type': ['BinarySensor'],
     powerSource: POWERSOURCE.BATTERY,


### PR DESCRIPTION
Didn't have the actual device to try this out, but it seems  like a typo to me.