### PR TITLE
Fix calculation for Hue/Saturation

### DIFF
--- a/zb-property.js
+++ b/zb-property.js
@@ -166,14 +166,14 @@ class ZigbeeProperty extends Property {
     if (attrEntry.attrId == ATTR_ID.LIGHTINGCOLORCTRL.CURRENTHUE) {
       // We expect that we'll always get the hue in one call, and
       // the saturation in a later call. For hue, we just record it.
-      this.hue = attrEntry.attrData;
+      this.hue = (attrEntry.attrData / 254) * 360;
       return [];
     }
     if (attrEntry.attrId != ATTR_ID.LIGHTINGCOLORCTRL.CURRENTSATURATION) {
       return [];
     }
     const hue = this.hue;
-    const sat = attrEntry.attrData;
+    const sat = (attrEntry.attrData / 254) * 100;
     let level = 0;
     const levelProperty = this.device.findProperty('_level');
     if (levelProperty) {


### PR DESCRIPTION
The Color class epxetcs Hue in the range 0-360 and Saturation 0-100.
Zigbee uses 0-254 for both of these.

The code which sets the color:
https://github.com/mozilla-iot/zigbee-adapter/blob/c3a9f90e746e35f6c8c5ef30c111bc53859bf9a2/zb-property.js#L723
does the correct scaling.

This PR fixes the parsing code which takes the zigbee values and converts
them back into RGB colors to apply the correct inverse scaling.