### PR TITLE
Fix typo in zoneType logic

### DIFF
--- a/zb-adapter.js
+++ b/zb-adapter.js
@@ -1424,9 +1424,9 @@ class ZigbeeAdapter extends Adapter {
           zclSeqNum: readFrame.zcl.seqNum,
           callback: () => {
             node.readingZoneType = false;
-            if (this.hasOwnProperty('zoneType')) {
-              this.setClassifierAttributesPopulated(this,
-                                                    this.ssIasZoneEndpoint);
+            if (node.hasOwnProperty('zoneType')) {
+              this.setClassifierAttributesPopulated(node,
+                                                    node.ssIasZoneEndpoint);
             }
           },
           timeoutFunc: () => {


### PR DESCRIPTION
This caused delays when adding iasZone sensors
(water leak, motion sensor, etc). Things would eventually
recover when the sensor sent in some data, but it might
take a couple minutes for this to occur.