### PR TITLE
Added support for the ConBee watchdog timer

### DIFF
--- a/deconz-driver.js
+++ b/deconz-driver.js
@@ -252,8 +252,8 @@ class DeconzDriver extends ZigbeeDriver {
 
   close() {
     if (this.watchDogTimeout) {
-      clearTimeout(this.WatchDogTimeout);
-      this.WatchDogTimeout = null;
+      clearTimeout(this.watchDogTimeout);
+      this.watchDogTimeout = null;
     }
     this.serialPort.close();
   }
@@ -517,10 +517,10 @@ class DeconzDriver extends ZigbeeDriver {
                                   WATCHDOG_TIMEOUT_SECS,
                                   WATCHDOG_PRIORITY));
     if (this.watchDogTimeout) {
-      clearTimeout(this.WatchDogTimeout);
-      this.WatchDogTimeout = null;
+      clearTimeout(this.watchDogTimeout);
+      this.watchDogTimeout = null;
     }
-    this.WatchDogTimeout = setTimeout(() => {
+    this.watchDogTimeout = setTimeout(() => {
       this.watchDogTimeout = null;
       this.kickWatchDog();
     }, (WATCHDOG_TIMEOUT_SECS / 2) * 1000);

--- a/zb-driver.js
+++ b/zb-driver.js
@@ -32,6 +32,7 @@ const EXTENDED_TIMEOUT_DELAY = 10 * 1000;
 const WAIT_RETRY_MAX = 3;   // includes initial send
 
 const PERMIT_JOIN_PRIORITY = 1;
+const WATCHDOG_PRIORITY = 1;
 
 const SEND_FRAME = 0x01;
 const WAIT_FRAME = 0x02;
@@ -812,6 +813,7 @@ module.exports = {
   Command,
   FUNC,
   PERMIT_JOIN_PRIORITY,
+  WATCHDOG_PRIORITY,
   RESOLVE_SET_PROPERTY,
   SEND_FRAME,
   WAIT_FRAME,


### PR DESCRIPTION
With the Conbee the watchdog triggering was largely
invisible since there was a usb-to-serial converter attached
to the AVR, and the AVR reset would only be noticed if there
were commands being processed at the time.

With the ConBee II, the MCU is directly connected to USB, so
when the MCU resets, it would dsiconnect from USB and would
need to be re-enumerated before comms would work.

Kicking the watchdog prevents the dongle from resetting.