### PR TITLE
Fixes #112 - typo in zb-adapter.js (enumerateDoneCb)

### DIFF
--- a/zb-adapter.js
+++ b/zb-adapter.js
@@ -373,7 +373,7 @@ class ZigbeeAdapter extends Adapter {
         FUNC(this, this.enumerateNextNode, []),
       ]);
       this.enumerateIterCb(node);
-    } else if (this.enumerateDonCb) {
+    } else if (this.enumerateDoneCb) {
       this.enumerateDoneCb(node);
     }
   }


### PR DESCRIPTION
It turns out that the done callback isn't actually used
in the adapter, so this change won't affect anything but
it's good to get rid of the typo.