### PR TITLE
Fix Match_Desc_rsp with the correct NWKAddrOfInterest

### DIFF
--- a/zb-adapter.js
+++ b/zb-adapter.js
@@ -623,7 +623,7 @@ class ZigbeeAdapter extends Adapter {
       clusterId: zdo.CLUSTER_ID.MATCH_DESCRIPTOR_RESPONSE,
       zdoSeq: reqFrame.zdoSeq,
       status: 0,
-      zdoAddr16: node.addr16,
+      zdoAddr16: reqFrame.zdoAddr16,
       endpoints: [endpoint],
     }));
   }


### PR DESCRIPTION
Hi,

I was trying to add some Nyce Open/Close sensors I have. But, they were not working. So, digging arround I discovered that the Match Descriptor Response was sending an invalid NWKAddrOfInterest address forcing the sensor to leave the network.

The NWKAddrOfInterest of the response must be the same of the request. The device is asking if the coordinator has the cluster. We need to answer that the coordinator has it, not the device.

At Zigbee specification, page 165, you can find this reference:

"If the NWKAddrOfInterest field of the original Match_Desc_req was not equal to
the broadcast network address for all devices for which macRxOnWhenIdle =
TRUE (0xfffd), the remote device shall set the NWKAddrOfInterest field to the
same network address that was specified in the original Match_Desc_req
command."

After this change, all my Nyce Open/Close sensors joined the network without any problem.

regards
