### PR TITLE
Added support for Xiaomi/Aqara Magic Cube

### DIFF
--- a/zb-constants.js
+++ b/zb-constants.js
@@ -129,6 +129,8 @@ const CLUSTER_ID = {
   GENPOLLCTRL: zclId.cluster('genPollCtrl').value,
   GENPOWERCFG: zclId.cluster('genPowerCfg').value,
   GENSCENES: zclId.cluster('genScenes').value,
+  GENMULTISTATEINPUT: zclId.cluster('genMultistateInput').value,
+  GENANALOGINPUT: zclId.cluster('genAnalogInput').value,
   HAELECTRICAL: zclId.cluster('haElectricalMeasurement').value,
   HVACTHERMOSTAT: zclId.cluster('hvacThermostat').value,
   HVACFANCTRL: zclId.cluster('hvacFanCtrl').value,

--- a/zb-property.js
+++ b/zb-property.js
@@ -574,7 +574,7 @@ class ZigbeeProperty extends Property {
    * @method parseNumericHundredthsAttr
    *
    * Converts generic numeric attributes in a number, and divides
-   * the number by 10.
+   * the number by 100.
    */
   parseNumericHundredthsAttr(attrEntry) {
     const value = attrEntry.attrData / 100;
@@ -640,6 +640,50 @@ class ZigbeeProperty extends Property {
       propertyValue,
       `${(propertyValue ? 'on' : 'off')} (${attrEntry.attrData})`,
     ];
+  }
+  
+  /**
+   * @method parseCubeNumericAttr
+   *
+   * Convert numeric state values to cube action
+   */
+  parseCubeNumericAttr(attrEntry) {
+    let cubeAction = 'none';
+    switch (attrEntry.attrData) {
+      /* Shake/Clear State */
+      case 0:
+        cubeAction = 'shake';
+        break;
+      /* Wake Up */
+      case 2:
+        cubeAction = 'wakeup';
+        break;
+      /* Flip Cube 90° */
+      case 65: case 66: case 68: case 69:
+      case 72: case 74: case 75: case 77:
+      case 80: case 81: case 83: case 84:
+      case 89: case 90: case 92: case 93:
+      case 96: case 98: case 99: case 101:
+      case 104: case 105: case 107: case 108:
+        cubeAction = 'flip90';
+        break;
+      /* Flip Cube 180° */
+      case 128: case 129: case 130: case 131: case 132: case 133:
+        cubeAction = 'flip180';
+        break;
+      /* Slide */
+      case 256: case 258: case 259: case 261: case 260: case 257:
+        cubeAction = 'slide';
+        break;
+      /* Tap */
+      case 512: case 514: case 515: case 517: case 516: case 513:
+        cubeAction = 'tap';
+        break;
+      default:
+        cubeAction = 'unknown (' + attrEntry.attrData + ')';
+        break;
+    }
+    return [cubeAction, `${cubeAction}`];
   }
 
   /**

--- a/zb-property.js
+++ b/zb-property.js
@@ -641,7 +641,7 @@ class ZigbeeProperty extends Property {
       `${(propertyValue ? 'on' : 'off')} (${attrEntry.attrData})`,
     ];
   }
-  
+
   /**
    * @method parseCubeNumericAttr
    *
@@ -680,7 +680,7 @@ class ZigbeeProperty extends Property {
         cubeAction = 'tap';
         break;
       default:
-        cubeAction = 'unknown (' + attrEntry.attrData + ')';
+        cubeAction = `unknown (${attrEntry.attrData})`;
         break;
     }
     return [cubeAction, `${cubeAction}`];

--- a/zb-xiaomi.js
+++ b/zb-xiaomi.js
@@ -58,37 +58,6 @@ const MODEL_IDS = {
       },
     },
   },
-  'lumi.sensor_magnet.aq2': {
-    name: 'magnet',
-    '@type': ['BinarySensor'],
-    powerSource: POWERSOURCE.BATTERY,
-    activeEndpoints: {
-      1: {
-        profileId: PROFILE_ID.ZHA_HEX,
-        inputClusters: [
-          CLUSTER_ID.GENBASIC_HEX,
-          CLUSTER_ID.GENONOFF_HEX,
-        ],
-        outputClusters: [],
-      },
-    },
-    properties: {
-      on: {
-        descr: {
-          '@type': 'BooleanProperty',
-          label: 'Open',
-          type: 'boolean',
-          description: 'Magnet Sensor',
-        },
-        profileId: PROFILE_ID.ZHA,
-        endpoint: 1,
-        clusterId: CLUSTER_ID.GENONOFF,
-        attr: 'onOff',
-        value: false,
-        parseValueFromAttr: 'parseOnOffAttr',
-      },
-    },
-  },
   'lumi.sensor_switch': {
     name: 'switch',
     '@type': ['BinarySensor'],
@@ -406,6 +375,93 @@ const MODEL_IDS = {
       },
     },
   },
+  'lumi.sensor_cube': {
+    name: 'sensor-cube',
+    '@type': ['BinarySensor'],
+    powerSource: POWERSOURCE.BATTERY,
+    activeEndpoints: {
+      1: {
+        profileId: PROFILE_ID.ZHA_HEX,
+        inputClusters: [
+          CLUSTER_ID.GENBASIC_HEX,
+          CLUSTER_ID.GENOTA_HEX,
+          CLUSTER_ID.GENMULTISTATEINPUT_HEX,
+        ],
+        outputClusters: [],
+      },
+      2: {
+        profileId: PROFILE_ID.ZHA_HEX,
+        inputClusters: [
+          CLUSTER_ID.GENMULTISTATEINPUT_HEX,
+        ],
+        outputClusters: [],
+      },
+      3: {
+        profileId: PROFILE_ID.ZHA_HEX,
+        inputClusters: [
+          CLUSTER_ID.GENANALOGINPUT_HEX,
+        ],
+        outputClusters: [],
+      },
+    },
+    properties: {
+      transitionString: {
+        descr: {
+          '@type': 'MultiClickProperty',
+          label: 'State',
+          type: 'string',
+          description: 'Cube Motion Sensor',
+          readOnly: true,
+        },
+        profileId: PROFILE_ID.ZHA,
+        endpoint: 2,
+        clusterId: CLUSTER_ID.GENMULTISTATEINPUT,
+        attr: 'presentValue',
+        value: '',
+        parseValueFromAttr: 'parseCubeNumericAttr',
+      },
+      /*
+      transitionNumeric: {
+        descr: {
+          '@type': 'MultiClickProperty',
+          label: 'State',
+          type: 'number',
+          description: 'Cube Motion Sensor',
+          readOnly: true,
+        },
+        profileId: PROFILE_ID.ZHA,
+        endpoint: 2,
+        clusterId: CLUSTER_ID.GENMULTISTATEINPUT,
+        attr: 'presentValue',
+        value: 0,
+        parseValueFromAttr: 'parseNumericAttr',
+      },
+      */
+      rotate: {
+        descr: {
+          '@type': 'MultiClickProperty',
+          label: 'Rotation',
+          type: 'number',
+          unit: '°',
+          description: 'Cube Rotation',
+          minimum: -180,
+          maximum: 180,
+          readOnly: true,
+        },
+        profileId: PROFILE_ID.ZHA,
+        endpoint: 3,
+        clusterId: CLUSTER_ID.GENANALOGINPUT,
+        attr: 'presentValue',
+        value: '',
+        parseValueFromAttr: 'parseNumericAttr',
+      },
+    },
+  },
+};
+
+const MODEL_IDS_MAP = {
+  'lumi.sensor_magnet.aq2': 'lumi.sensor_magnet',
+  'lumi.sensor_cube.aqgl01': 'lumi.sensor_cube',
 };
 
 class XiaomiFamily extends ZigbeeFamily {
@@ -419,15 +475,21 @@ class XiaomiFamily extends ZigbeeFamily {
   }
 
   identify(node) {
-    if (MODEL_IDS.hasOwnProperty(node.modelId)) {
+    if (MODEL_IDS.hasOwnProperty(this.mapModelID(node))) {
       this.init(node);
       return true;
     }
     return false;
   }
-
+  
+  mapModelID(node) {
+    if (MODEL_IDS_MAP.hasOwnProperty(node.modelId))
+      return MODEL_IDS_MAP[node.modelId];
+    return node.modelId;
+  }
+  
   init(node) {
-    const attribs = MODEL_IDS[node.modelId];
+    const attribs = MODEL_IDS[this.mapModelID(node)];
     if (!attribs) {
       console.log('xiaomi.classify: Unknown modelId:', node.modelId);
       return;

--- a/zb-xiaomi.js
+++ b/zb-xiaomi.js
@@ -481,13 +481,14 @@ class XiaomiFamily extends ZigbeeFamily {
     }
     return false;
   }
-  
+
   mapModelID(node) {
-    if (MODEL_IDS_MAP.hasOwnProperty(node.modelId))
+    if (MODEL_IDS_MAP.hasOwnProperty(node.modelId)) {
       return MODEL_IDS_MAP[node.modelId];
+    }
     return node.modelId;
   }
-  
+
   init(node) {
     const attribs = MODEL_IDS[this.mapModelID(node)];
     if (!attribs) {


### PR DESCRIPTION
I've added the cube controller for two different models "lumi.sensor_cube" and "lumi.sensor_cube.aqgl01" (https://www.aqara.com/us/cube.html, https://zigbee.blakadder.com/Xiaomi_MFKZQ01LM.html).
The cube provides two different properties:
* a state value, which converts the detected movement to one of the following states:
flip90, flip180, slide, tap, shake, wakeup
* the number of degrees, when the cube is rotated (the range is -180° to 180°)

It doesn't seem to be possible to parse the same zigbee property value more than once. It would probably be nicer if the different states would be boolean on/off values. However, the text values of the listed states can be used in the rules to trigger actions.

![zigbee_adapter_cube_controller](https://user-images.githubusercontent.com/64744086/85213034-61a6bd00-b359-11ea-8a4d-27469a3e8c0d.png)


