### PR TITLE
make percentage multiple of 0.1

### DIFF
--- a/zb-classifier.js
+++ b/zb-classifier.js
@@ -261,6 +261,7 @@ class ZigbeeClassifier {
         unit: 'percent',
         minimum: 0,
         maximum: 100,
+        multipleOf: 0.1,
       },
       endpoint.profileId,             // profileId
       lightingColorCtrlEndpoint,      // endpoint
@@ -296,6 +297,7 @@ class ZigbeeClassifier {
         unit: 'percent',
         minimum: 0,
         maximum: 100,
+        multipleOf: 0.1,
       },
       endpoint.profileId,             // profileId
       lightingColorCtrlEndpoint,      // endpoint
@@ -388,6 +390,7 @@ class ZigbeeClassifier {
         unit: 'percent',
         minimum: 0,
         maximum: 100,
+        multipleOf: 0.1,
       },
       endpoint.profileId,             // profileId
       genLevelCtrlEndpoint,           // endpoint
@@ -436,6 +439,7 @@ class ZigbeeClassifier {
         unit: 'percent',
         minimum: 0,
         maximum: 100,
+        multipleOf: 0.1,
       },
       endpoint.profileId,             // profileId
       genLevelCtrlEndpoint,           // endpoint
@@ -506,6 +510,7 @@ class ZigbeeClassifier {
         unit: 'percent',
         minimum: 0,
         maximum: 100,
+        multipleOf: 0.1,
         readOnly: true,
       },
       PROFILE_ID.ZHA,                 // profileId


### PR DESCRIPTION
https://github.com/mozilla-iot/gateway/issues/2571

I also noticed that properties have 'label' attributes. Shouldn't those be 'title' now? Or is that only for things?